### PR TITLE
Minor advancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a Github action, you can use it to extract your Rust crate version. Read
 ```yaml
 - name: Crate Version
   id: crate-version
-  uses: colathro/crate-version@1.0.0
+  uses: colathro/crate-version@2.0.0
   with:
     file: "./Cargo.toml"
 ```

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ This is a Github action, you can use it to extract your Rust crate version. Read
 
 All arguments are of type string.
 
-| Name | Required | Description                    |
-| ---- | -------- | ------------------------------ |
-| file | Yes      | The relative path of toml file |
+| Name | Required | Description                    | Default    |
+| ---- | -------- | ------------------------------ | ---------- |
+| file | False    | The relative path of toml file | Cargo.toml |
 
 ### Cargo.toml Example
 
@@ -55,9 +55,8 @@ jobs:
 
       - name: Crate Version
         id: crate-version
-        uses: colathro/crate-version@1.0.0
-        with:
-          file: "./Cargo.toml"
+        uses: colathro/crate-version@2.0.0
+
       - name: Use Version Output
         run: echo ${{ steps.crate-version.outputs.version }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ outputs:
     description: "The version of the crate"
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ branding:
 inputs:
   file:
     description: "The relative path of toml file"
-    required: true
+    required: false
 
 outputs:
   version:

--- a/dist/index.js
+++ b/dist/index.js
@@ -11,7 +11,7 @@ const toml = __nccwpck_require__(2521);
 
 function run() {
   try {
-    const fileName = core.getInput("file", { required: true });
+    const fileName = core.getInput("file", { required: false }) || "Cargo.toml";
     const filePath = path.join(process.env.GITHUB_WORKSPACE, fileName);
 
     let tomlContent = getTomlContent(filePath);
@@ -23,7 +23,7 @@ function run() {
       throw Error("version not found");
     }
 
-    core.setOutput("version", version);
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `version=${version}`);
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const toml = require("@iarna/toml");
 
 function run() {
   try {
-    const fileName = core.getInput("file") || "Cargo.json";
+    const fileName = core.getInput("file", { required: false }) || "Cargo.json";
     const filePath = path.join(process.env.GITHUB_WORKSPACE, fileName);
 
     let tomlContent = getTomlContent(filePath);

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const toml = require("@iarna/toml");
 
 function run() {
   try {
-    const fileName = core.getInput("file", { required: true });
+    const fileName = core.getInput("file") || "Cargo.json";
     const filePath = path.join(process.env.GITHUB_WORKSPACE, fileName);
 
     let tomlContent = getTomlContent(filePath);

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function run() {
       throw Error("version not found");
     }
 
-    core.setOutput("version", version);
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `version=${version}`);
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
A bit dirty cuz it was edited via Github UI, but it works either way.

Changes:
- Made `file` optional and default to `Cargo.toml`
- Switched from deprecated `set-output` in favor of environment files
- Upped node version cuz Github wanted me to

Usage is completely unchanged and everything is fully compatible with that was before except ergonomics are now better 🙏🏻